### PR TITLE
fix package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
 , "scripts" : {"start": "./bin/babelweb"}
 , "dependencies":
   { "socket.io": "0.7.x"
-  , "connect": "1.6.x" }
+  , "connect": "1.7.x" }
 , "devDependencies" :
   { "ronn" : "0.3.x" }
-, "engines": { "node": "0.4.x" }
+, "engines": { "node": "0.6.x" }
 , "directories" :
   { "doc" : "./doc"
   , "man" : "./man1"


### PR DESCRIPTION
"connect" package doesn't currently have version 1.6.x available; "node"
current stable version is 0.6.x. The changes were necessary to fix "make
install" in a current invironment, babeld did work after that.
