### PR TITLE
Fix an infinite loop on connection error (this fixes issue #3)

### DIFF
--- a/babelNode.js
+++ b/babelNode.js
@@ -116,7 +116,6 @@
         if(typeof state.self.id !== "undefined") {
           closeCallback(node, state.self.id);
         }
-        if (error) { return; /* already handled */ }
         if(!connectionFailure) {
           log("error", "Babel socket close: reconnecting in 1 second.");
         }
@@ -125,11 +124,10 @@
       });
 
       client.on('error', function () {
-        if(!connectionFailure) {
-          log("error", "Babel socket close: reconnecting in 1 second.");
-        }
-        connectionFailure = true;
-        setTimeout(babelConnect, 1000);
+        /* Do nothing, 'close' will be called in any case.
+         * http://nodejs.org/api/net.html#net_event_error_1
+         */
+        return;
       });
 
     }


### PR DESCRIPTION
Sometimes, an error happens on the socket, but the 'close' event is called
with "had_errors" set to False.  In this case, we would could ourselves
recursively _twice_, which leads to an exponential number of recursive
calls over time.

This happens, for instance, when DNS resolution fails.

According to the doc, we only need to handle the 'close' event:

  http://nodejs.org/api/net.html#net_event_error_1
