### PR TITLE
updated to socket.io version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,32 +1,48 @@
 {
-  "name": "babelweb"
-, "version": "0.4.0"
-, "description": "Web-based monitoring tool for the Babel routing protocol"
-, "homepage": "http://gabriel.kerneis.info/software/babelweb"
-, "keywords": [ "babel", "routing", "monitoring" ]
-, "author": "Gabriel Kerneis <gabriel@kerneis.info> (http://gabriel.kerneis.info/)"
-, "repository":
-  { "type": "git"
-  , "url": "git://git.wifi.pps.univ-paris-diderot.fr/babelweb.git" }
-, "scripts" : {"start": "./bin/babelweb"}
-, "dependencies":
-  { "socket.io": "0.9.x"
-  , "connect": "2.7.x" }
-, "devDependencies" :
-  { "ronn" : "0.4.x" }
-, "engines": { "node": "0.10.x" }
-, "directories" :
-  { "doc" : "./doc"
-  , "man" : "./man1"
-  , "bin" : "./bin" }
-, "bin" : { "babelweb" : "./bin/babelweb" }
-, "preferGlobal": true
-, "licenses" :
-  [ { "type" : "MIT"
-    , "url" : "http://git.wifi.pps.univ-paris-diderot.fr/?p=babelweb.git;a=blob_plain;f=LICENSE"
-    }
-  , { "type" : "3-clause BSD"
-    , "url" : "http://git.wifi.pps.univ-paris-diderot.fr/?p=babelweb.git;a=blob_plain;f=LICENSE.d3"
+  "name": "babelweb",
+  "version": "0.4.0",
+  "description": "Web-based monitoring tool for the Babel routing protocol",
+  "homepage": "http://gabriel.kerneis.info/software/babelweb",
+  "keywords": [
+    "babel",
+    "routing",
+    "monitoring"
+  ],
+  "author": "Gabriel Kerneis <gabriel@kerneis.info> (http://gabriel.kerneis.info/)",
+  "repository": {
+    "type": "git",
+    "url": "git://git.wifi.pps.univ-paris-diderot.fr/babelweb.git"
+  },
+  "scripts": {
+    "start": "./bin/babelweb"
+  },
+  "dependencies": {
+    "connect": "2.7.x",
+    "socket.io": "^2.0.3"
+  },
+  "devDependencies": {
+    "ronn": "0.4.x"
+  },
+  "engines": {
+    "node": "0.10.x"
+  },
+  "directories": {
+    "doc": "./doc",
+    "man": "./man1",
+    "bin": "./bin"
+  },
+  "bin": {
+    "babelweb": "./bin/babelweb"
+  },
+  "preferGlobal": true,
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://git.wifi.pps.univ-paris-diderot.fr/?p=babelweb.git;a=blob_plain;f=LICENSE"
+    },
+    {
+      "type": "3-clause BSD",
+      "url": "http://git.wifi.pps.univ-paris-diderot.fr/?p=babelweb.git;a=blob_plain;f=LICENSE.d3"
     }
   ]
 }

--- a/server.js
+++ b/server.js
@@ -86,26 +86,20 @@ var connect = require('connect'),
   http = require('http'),
   app = connect().use(connect.static(__dirname + '/static')),
   server = http.createServer(app),
-  io = require('socket.io').listen(server);
+  io = require('socket.io')({
+    transports: [
+      'websocket',
+      // disabled by default
+      'flashsocket',
+      'htmlfile',
+      'xhr-polling',
+      'jsonp-polling'
+    ]
+  }).listen(server);
 
 if (config.verbose) { app.use(connect.logger('dev')); } // XXX
 
 server.listen(config.port, config.host);
-
-io.configure(function () {
-  io.enable('browser client minification');
-  io.enable('browser client etag');
-  io.set('log level', config.verbose ? 3 : 1);
-
-  io.set('transports', [
-    'websocket',
-    // disabled by default
-    'flashsocket',
-    'htmlfile',
-    'xhr-polling',
-    'jsonp-polling'
-  ]);
-});
 
 /* Send updates to clients when they connect */
 


### PR DESCRIPTION
I quickly updated to socket.io version 2.0.3 as I encountered compatibility issues with most recent versions of Node in the policyfile dependency of socket.io 0.9.

Although it is working on my system now, please check if everything looks good. I found no solution to set the `browser client minification` as well as `browser client etag` like with socket.io version 0.9.x.

Cheers